### PR TITLE
SFW-149: Updates to LICENSE, README & podspec

### DIFF
--- a/Example/STWSocialKit.xcodeproj/project.pbxproj
+++ b/Example/STWSocialKit.xcodeproj/project.pbxproj
@@ -586,7 +586,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				MODULE_NAME = ExampleApp;
 				OTHER_SWIFT_FLAGS = "$(inherited) \"-D\" \"COCOAPODS\" -DDEBUG -DSTWKIT";
-				PRODUCT_BUNDLE_IDENTIFIER = "org.cocoapods.demo.$(PRODUCT_NAME:rfc1034identifier)";
+				PRODUCT_BUNDLE_IDENTIFIER = "org.cocoapods.demo.STWSocialKit-Example";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 3.0;
 			};
@@ -604,7 +604,7 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				MODULE_NAME = ExampleApp;
-				PRODUCT_BUNDLE_IDENTIFIER = "org.cocoapods.demo.$(PRODUCT_NAME:rfc1034identifier)";
+				PRODUCT_BUNDLE_IDENTIFIER = "org.cocoapods.demo.STWSocialKit-Example";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 3.0;
 			};

--- a/Example/STWSocialKit/AppDelegate.swift
+++ b/Example/STWSocialKit/AppDelegate.swift
@@ -6,9 +6,9 @@
 //
 //  The MIT License (MIT)
 //
-//  Copyright (c) 2018 Stanwood GmbH (www.stanwood.io)
+//  Copyright (c) 2018 stanwood GmbH
 //
-//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  Distributed under MIT licence.
 //  of this software and associated documentation files (the "Software"), to deal
 //  in the Software without restriction, including without limitation the rights
 //  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell

--- a/Example/STWSocialKit/AppDelegate.swift
+++ b/Example/STWSocialKit/AppDelegate.swift
@@ -1,13 +1,13 @@
 //
 //  AppDelegate.swift
-//  STWSocialKit
+//  StanwoodSocial
 //
 //  Created by Tal Zion on 11/28/2016.
-//  Copyright (c) 2016 Tal Zion. All rights reserved.
+//  Distributed under MIT licence.
 //
 
 import UIKit
-import STWSocialKit
+import StanwoodSocial
 
 @UIApplicationMain
 class AppDelegate: UIResponder, UIApplicationDelegate {

--- a/Example/STWSocialKit/AppDelegate.swift
+++ b/Example/STWSocialKit/AppDelegate.swift
@@ -3,8 +3,28 @@
 //  StanwoodSocial
 //
 //  Created by Tal Zion on 11/28/2016.
-//  Distributed under MIT licence.
 //
+//  The MIT License (MIT)
+//
+//  Copyright (c) 2018 Stanwood GmbH (www.stanwood.io)
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
 
 import UIKit
 import StanwoodSocial

--- a/Example/STWSocialKit/Base.lproj/LaunchScreen.xib
+++ b/Example/STWSocialKit/Base.lproj/LaunchScreen.xib
@@ -1,11 +1,11 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="11542" systemVersion="15G1108" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES" colorMatched="YES">
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14113" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="11524"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14088"/>
         <capability name="Constraints with non-1.0 multipliers" minToolsVersion="5.1"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -22,7 +22,7 @@
                     <color key="textColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                     <nil key="highlightedColor"/>
                 </label>
-                <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="STWSocialKit" textAlignment="center" lineBreakMode="middleTruncation" baselineAdjustment="alignBaselines" minimumFontSize="18" translatesAutoresizingMaskIntoConstraints="NO" id="kId-c2-rCX">
+                <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="StanwoodSocial" textAlignment="center" lineBreakMode="middleTruncation" baselineAdjustment="alignBaselines" minimumFontSize="18" translatesAutoresizingMaskIntoConstraints="NO" id="kId-c2-rCX">
                     <rect key="frame" x="20" y="140" width="441" height="43"/>
                     <fontDescription key="fontDescription" type="boldSystem" pointSize="36"/>
                     <color key="textColor" white="1" alpha="1" colorSpace="calibratedWhite"/>

--- a/Example/STWSocialKit/Base.lproj/LaunchScreen.xib
+++ b/Example/STWSocialKit/Base.lproj/LaunchScreen.xib
@@ -16,7 +16,7 @@
             <rect key="frame" x="0.0" y="0.0" width="480" height="480"/>
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
-                <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="  Copyright (c) 2016 Stanwood GmbH. All rights reserved." textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumFontSize="9" translatesAutoresizingMaskIntoConstraints="NO" id="8ie-xW-0ye">
+                <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="  Copyright ©️ 2018 Stanwood GmbH. All rights reserved." textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumFontSize="9" translatesAutoresizingMaskIntoConstraints="NO" id="8ie-xW-0ye">
                     <rect key="frame" x="20" y="439" width="441" height="21"/>
                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                     <color key="textColor" white="1" alpha="1" colorSpace="calibratedWhite"/>

--- a/Example/STWSocialKit/CollectionDataSource.swift
+++ b/Example/STWSocialKit/CollectionDataSource.swift
@@ -1,9 +1,9 @@
 //
 //  DataSource.swift
-//  Mach_Dich_Krass
+//  StanwoodSocial
 //
-//  Created by Tal Zion on 01/05/2016.
-//  Copyright © 2016 Stanwood GmbH. All rights reserved.
+//  Copyright (c) 2018 stanwood GmbH
+//  Distributed under MIT licence.
 //
 
 import UIKit

--- a/Example/STWSocialKit/CollectionDelegate.swift
+++ b/Example/STWSocialKit/CollectionDelegate.swift
@@ -1,9 +1,9 @@
 //
 //  CollectionDelegate.swift
-//  Mach_Dich_Krass
+//  StanwoodSocial
 //
-//  Created by Tal Zion on 02/05/2016.
-//  Copyright © 2016 Stanwood GmbH. All rights reserved.
+//  Copyright (c) 2018 stanwood GmbH
+//  Distributed under MIT licence.
 //
 
 import Foundation

--- a/Example/STWSocialKit/Info.plist
+++ b/Example/STWSocialKit/Info.plist
@@ -4,6 +4,8 @@
 <dict>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>en</string>
+	<key>CFBundleDisplayName</key>
+	<string>StanwoodSocial</string>
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>
@@ -35,7 +37,7 @@
 	<key>FacebookAppID</key>
 	<string>1270045609684804</string>
 	<key>FacebookDisplayName</key>
-	<string>STWSocialKit</string>
+	<string>StanwoodSocial</string>
 	<key>LSApplicationQueriesSchemes</key>
 	<array>
 		<string>fbapi</string>

--- a/Example/STWSocialKit/SMAuthor.swift
+++ b/Example/STWSocialKit/SMAuthor.swift
@@ -1,9 +1,9 @@
 //
 //  SMAuthor.swift
-//  Mach_Dich_Krass
+//  StanwoodSocial
 //
-//  Created by Tal Zion on 31/08/2016.
-//  Copyright © 2016 Stanwood GmbH. All rights reserved.
+//  Copyright (c) 2018 stanwood GmbH
+//  Distributed under MIT licence.
 //
 
 import Foundation

--- a/Example/STWSocialKit/SMPost.swift
+++ b/Example/STWSocialKit/SMPost.swift
@@ -1,9 +1,9 @@
 //
 //  SMPost.swift
-//  Mach_Dich_Krass
+//  StanwoodSocial
 //
-//  Created by Tal Zion on 31/08/2016.
-//  Copyright © 2016 Stanwood GmbH. All rights reserved.
+//  Copyright (c) 2018 stanwood GmbH
+//  Distributed under MIT licence.
 //
 
 import Foundation

--- a/Example/STWSocialKit/SMPostCell.swift
+++ b/Example/STWSocialKit/SMPostCell.swift
@@ -11,7 +11,7 @@ import YouTubePlayer
 import FontAwesome_swift
 import FBSDKLoginKit
 import FBSDKCoreKit
-import STWSocialKit
+import StanwoodSocial
 
 enum SocialAction: Int {
     case like

--- a/Example/STWSocialKit/SMPostCell.swift
+++ b/Example/STWSocialKit/SMPostCell.swift
@@ -1,9 +1,9 @@
 //
 //  SMPostCell.swift
-//  Mach_Dich_Krass
+//  StanwoodSocial
 //
-//  Created by Tal Zion on 31/08/2016.
-//  Copyright © 2016 Stanwood GmbH. All rights reserved.
+//  Copyright (c) 2018 stanwood GmbH
+//  Distributed under MIT licence.
 //
 
 import UIKit

--- a/Example/STWSocialKit/SMPosts.swift
+++ b/Example/STWSocialKit/SMPosts.swift
@@ -1,9 +1,9 @@
 //
 //  SMPosts.swift
-//  Mach_Dich_Krass
+//  StanwoodSocial
 //
-//  Created by Tal Zion on 31/08/2016.
-//  Copyright © 2016 Stanwood GmbH. All rights reserved.
+//  Copyright (c) 2018 stanwood GmbH
+//  Distributed under MIT licence.
 //
 
 import Foundation

--- a/Example/STWSocialKit/SocialConstants.swift
+++ b/Example/STWSocialKit/SocialConstants.swift
@@ -1,9 +1,9 @@
 //
 //  SocialConstants.swift
-//  STWSocialKit
+//  StanwoodSocial
 //
 //  Created by Tal Zion on 29/11/2016.
-//  Copyright © 2016 CocoaPods. All rights reserved.
+//  Distributed under MIT licence.
 //
 
 import Foundation

--- a/Example/STWSocialKit/SocialMediaDataSource.swift
+++ b/Example/STWSocialKit/SocialMediaDataSource.swift
@@ -1,9 +1,9 @@
 //
 //  SocialMediaDataSource.swift
-//  Mach_Dich_Krass
+//  StanwoodSocial
 //
-//  Created by Tal Zion on 31/08/2016.
-//  Copyright © 2016 Stanwood GmbH. All rights reserved.
+//  Copyright (c) 2018 stanwood GmbH
+//  Distributed under MIT licence.
 //
 
 import Foundation

--- a/Example/STWSocialKit/SocialMediaDelegate.swift
+++ b/Example/STWSocialKit/SocialMediaDelegate.swift
@@ -1,9 +1,9 @@
 //
 //  SocialMediaDelegate.swift
-//  Mach_Dich_Krass
+//  StanwoodSocial
 //
-//  Created by Tal Zion on 31/08/2016.
-//  Copyright © 2016 Stanwood GmbH. All rights reserved.
+//  Copyright (c) 2018 stanwood GmbH
+//  Distributed under MIT licence.
 //
 
 import Foundation

--- a/Example/STWSocialKit/SocialMediaDelegate.swift
+++ b/Example/STWSocialKit/SocialMediaDelegate.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 import UIKit
-import STWSocialKit
+import StanwoodSocial
 
 protocol SocialMediaLoadDelegate {
     

--- a/Example/STWSocialKit/SocialMediaViewController.swift
+++ b/Example/STWSocialKit/SocialMediaViewController.swift
@@ -3,11 +3,11 @@
 //  Mach_Dich_Krass
 //
 //  Created by Tal Zion on 31/08/2016.
-//  Copyright © 2016 Stanwood GmbH. All rights reserved.
+//  Distributed under MIT licence.
 //
 
 import UIKit
-import STWSocialKit
+import StanwoodSocial
 
 class SocialMediaViewController: UIViewController {
 

--- a/Example/STWSocialKit/SocialMediaViewController.swift
+++ b/Example/STWSocialKit/SocialMediaViewController.swift
@@ -1,8 +1,9 @@
 //
 //  SocialMediaViewController.swift
-//  Mach_Dich_Krass
+//  StanwoodSocial
 //
-//  Created by Tal Zion on 31/08/2016.
+//  Copyright (c) 2018 stanwood GmbH
+//  Distributed under MIT licence.
 //
 //  The MIT License (MIT)
 //

--- a/Example/STWSocialKit/SocialMediaViewController.swift
+++ b/Example/STWSocialKit/SocialMediaViewController.swift
@@ -3,8 +3,28 @@
 //  Mach_Dich_Krass
 //
 //  Created by Tal Zion on 31/08/2016.
-//  Distributed under MIT licence.
 //
+//  The MIT License (MIT)
+//
+//  Copyright (c) 2018 Stanwood GmbH (www.stanwood.io)
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
 
 import UIKit
 import StanwoodSocial

--- a/Example/STWSocialKit/ViewController.swift
+++ b/Example/STWSocialKit/ViewController.swift
@@ -3,8 +3,28 @@
 //  StanwoodSocial
 //
 //  Created by Tal Zion on 29/11/2016.
-//  Distributed under MIT licence.
 //
+//  The MIT License (MIT)
+//
+//  Copyright (c) 2018 Stanwood GmbH (www.stanwood.io)
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
 
 import UIKit
 

--- a/Example/STWSocialKit/ViewController.swift
+++ b/Example/STWSocialKit/ViewController.swift
@@ -2,7 +2,8 @@
 //  ViewController.swift
 //  StanwoodSocial
 //
-//  Created by Tal Zion on 29/11/2016.
+//  Copyright (c) 2018 stanwood GmbH
+//  Distributed under MIT licence.
 //
 //  The MIT License (MIT)
 //

--- a/Example/STWSocialKit/ViewController.swift
+++ b/Example/STWSocialKit/ViewController.swift
@@ -1,9 +1,9 @@
 //
 //  ViewController.swift
-//  STWSocialKit
+//  StanwoodSocial
 //
 //  Created by Tal Zion on 29/11/2016.
-//  Copyright © 2016 CocoaPods. All rights reserved.
+//  Distributed under MIT licence.
 //
 
 import UIKit

--- a/LICENSE
+++ b/LICENSE
@@ -1,1 +1,21 @@
-Copyright (c) 2016 stanwood GmbH
+The MIT License (MIT)
+
+Copyright (c) 2018 stanwood GmbH
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -338,4 +338,4 @@ s.dependency 'FBSDKLoginKit', '~> 4.17.0'
 
 ## License
 
-STWSocialKit is a private library. See the LICENSE file for more info
+STWSocialKit is under MIT licence. See the LICENSE file for more info

--- a/README.md
+++ b/README.md
@@ -1,10 +1,5 @@
 
-<p align="center">
-    <img src="Assets/STWSocial-Icon.png?raw=false" alt="STWSocialKit"/>
-</p>
-
-
-# STWSocialKit
+# StanwoodSocial
 
 
 [![Swift Version](https://img.shields.io/badge/Swift-3.0.x-orange.svg)]()
@@ -25,7 +20,7 @@ Instagram API Sandbox environment is boxed for any activity done outside the env
 
 ## Installation
 
-STWSocialKit is available through [Stanwood](https://github.com/stanwood/Cocoa_Pods_Specs.git) master specs. To install
+StanwoodSocial is available through [Stanwood](https://github.com/stanwood/Cocoa_Pods_Specs.git) master specs. To install
 it, simply add the following line to your Podfile, include the private source specs:
 
 ```ruby
@@ -33,7 +28,7 @@ source 'https://github.com/stanwood/Cocoa_Pods_Specs.git'
 use_frameworks!
 
     target 'STWProject' do
-    pod 'STWSocialKit'
+    pod 'StanwoodSocial'
 end
 ```
 
@@ -321,7 +316,7 @@ Simply call `STSocialManager.shared.logout` to log out the user from all service
 
 ## Dependencies
 
-`STWSocialKit` comes bundled with several libraries:
+`StanwoodSocial` comes bundled with several libraries:
 
 ```ruby
 # iOS Frameworks
@@ -338,4 +333,4 @@ s.dependency 'FBSDKLoginKit', '~> 4.17.0'
 
 ## License
 
-STWSocialKit is under MIT licence. See the LICENSE file for more info
+StanwoodSocial is under MIT licence. See the LICENSE file for more info

--- a/STWSocialKit/Classes/STAccount.swift
+++ b/STWSocialKit/Classes/STAccount.swift
@@ -3,10 +3,8 @@
 //  StanwoodSocial
 //
 //  Copyright (c) 2018 stanwood GmbH
-<<<<<<< Updated upstream
-=======
 //  Distributed under MIT licence.
->>>>>>> Stashed changes
+
 //
 //  The MIT License (MIT)
 //

--- a/STWSocialKit/Classes/STAccount.swift
+++ b/STWSocialKit/Classes/STAccount.swift
@@ -3,8 +3,28 @@
 //  Mach_Dich_Krass
 //
 //  Created by Tal Zion on 15/11/2016.
-//  Copyright © 2016 Stanwood GmbH. All rights reserved.
 //
+//  The MIT License (MIT)
+//
+//  Copyright (c) 2018 Stanwood GmbH (www.stanwood.io)
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
 
 import Foundation
 import Locksmith

--- a/STWSocialKit/Classes/STAccount.swift
+++ b/STWSocialKit/Classes/STAccount.swift
@@ -3,6 +3,10 @@
 //  StanwoodSocial
 //
 //  Copyright (c) 2018 stanwood GmbH
+<<<<<<< Updated upstream
+=======
+//  Distributed under MIT licence.
+>>>>>>> Stashed changes
 //
 //  The MIT License (MIT)
 //

--- a/STWSocialKit/Classes/STAccount.swift
+++ b/STWSocialKit/Classes/STAccount.swift
@@ -1,8 +1,8 @@
 //
 //  STAccount.swift
-//  Mach_Dich_Krass
+//  StanwoodSocial
 //
-//  Created by Tal Zion on 15/11/2016.
+//  Copyright (c) 2018 stanwood GmbH
 //
 //  The MIT License (MIT)
 //

--- a/STWSocialKit/Classes/STComment.swift
+++ b/STWSocialKit/Classes/STComment.swift
@@ -3,8 +3,28 @@
 //  Mach_Dich_Krass
 //
 //  Created by Tal Zion on 14/11/2016.
-//  Copyright © 2016 Stanwood GmbH. All rights reserved.
 //
+//  The MIT License (MIT)
+//
+//  Copyright (c) 2018 Stanwood GmbH (www.stanwood.io)
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
 
 import Foundation
 import ObjectMapper

--- a/STWSocialKit/Classes/STComment.swift
+++ b/STWSocialKit/Classes/STComment.swift
@@ -3,10 +3,8 @@
 //  StanwoodSocial
 //
 //  Copyright (c) 2018 stanwood GmbH
-<<<<<<< Updated upstream
-=======
 //  Distributed under MIT licence.
->>>>>>> Stashed changes
+
 //
 //  The MIT License (MIT)
 //

--- a/STWSocialKit/Classes/STComment.swift
+++ b/STWSocialKit/Classes/STComment.swift
@@ -3,6 +3,10 @@
 //  StanwoodSocial
 //
 //  Copyright (c) 2018 stanwood GmbH
+<<<<<<< Updated upstream
+=======
+//  Distributed under MIT licence.
+>>>>>>> Stashed changes
 //
 //  The MIT License (MIT)
 //

--- a/STWSocialKit/Classes/STComment.swift
+++ b/STWSocialKit/Classes/STComment.swift
@@ -1,8 +1,8 @@
 //
 //  STComment.swift
-//  Mach_Dich_Krass
+//  StanwoodSocial
 //
-//  Created by Tal Zion on 14/11/2016.
+//  Copyright (c) 2018 stanwood GmbH
 //
 //  The MIT License (MIT)
 //

--- a/STWSocialKit/Classes/STDefine.swift
+++ b/STWSocialKit/Classes/STDefine.swift
@@ -3,10 +3,8 @@
 //  StanwoodSocial
 //
 //  Copyright (c) 2018 stanwood GmbH
-<<<<<<< Updated upstream
-=======
 //  Distributed under MIT licence.
->>>>>>> Stashed changes
+
 //
 //  The MIT License (MIT)
 //

--- a/STWSocialKit/Classes/STDefine.swift
+++ b/STWSocialKit/Classes/STDefine.swift
@@ -3,6 +3,10 @@
 //  StanwoodSocial
 //
 //  Copyright (c) 2018 stanwood GmbH
+<<<<<<< Updated upstream
+=======
+//  Distributed under MIT licence.
+>>>>>>> Stashed changes
 //
 //  The MIT License (MIT)
 //

--- a/STWSocialKit/Classes/STDefine.swift
+++ b/STWSocialKit/Classes/STDefine.swift
@@ -1,8 +1,8 @@
 //
 //  STDefine.swift
-//  Mach_Dich_Krass
+//  StanwoodSocial
 //
-//  Created by Tal Zion on 24/11/2016.
+//  Copyright (c) 2018 stanwood GmbH
 //
 //  The MIT License (MIT)
 //

--- a/STWSocialKit/Classes/STDefine.swift
+++ b/STWSocialKit/Classes/STDefine.swift
@@ -3,8 +3,28 @@
 //  Mach_Dich_Krass
 //
 //  Created by Tal Zion on 24/11/2016.
-//  Copyright © 2016 Stanwood GmbH. All rights reserved.
 //
+//  The MIT License (MIT)
+//
+//  Copyright (c) 2018 Stanwood GmbH (www.stanwood.io)
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
 
 import Foundation
 

--- a/STWSocialKit/Classes/STExtensions.swift
+++ b/STWSocialKit/Classes/STExtensions.swift
@@ -3,10 +3,8 @@
 //  StanwoodSocial
 //
 //  Copyright (c) 2018 stanwood GmbH
-<<<<<<< Updated upstream
-=======
 //  Distributed under MIT licence.
->>>>>>> Stashed changes
+
 //
 //  The MIT License (MIT)
 //

--- a/STWSocialKit/Classes/STExtensions.swift
+++ b/STWSocialKit/Classes/STExtensions.swift
@@ -1,8 +1,8 @@
 //
 //  LikeType.swift
-//  Mach_Dich_Krass
+//  StanwoodSocial
 //
-//  Created by Tal Zion on 11/11/2016.
+//  Copyright (c) 2018 stanwood GmbH
 //
 //  The MIT License (MIT)
 //

--- a/STWSocialKit/Classes/STExtensions.swift
+++ b/STWSocialKit/Classes/STExtensions.swift
@@ -3,6 +3,10 @@
 //  StanwoodSocial
 //
 //  Copyright (c) 2018 stanwood GmbH
+<<<<<<< Updated upstream
+=======
+//  Distributed under MIT licence.
+>>>>>>> Stashed changes
 //
 //  The MIT License (MIT)
 //

--- a/STWSocialKit/Classes/STExtensions.swift
+++ b/STWSocialKit/Classes/STExtensions.swift
@@ -3,8 +3,28 @@
 //  Mach_Dich_Krass
 //
 //  Created by Tal Zion on 11/11/2016.
-//  Copyright © 2016 Stanwood GmbH. All rights reserved.
 //
+//  The MIT License (MIT)
+//
+//  Copyright (c) 2018 Stanwood GmbH (www.stanwood.io)
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
 
 import Foundation
 import OAuthSwift

--- a/STWSocialKit/Classes/STLike.swift
+++ b/STWSocialKit/Classes/STLike.swift
@@ -3,8 +3,28 @@
 //  Mach_Dich_Krass
 //
 //  Created by Tal Zion on 11/11/2016.
-//  Copyright © 2016 Stanwood GmbH. All rights reserved.
 //
+//  The MIT License (MIT)
+//
+//  Copyright (c) 2018 Stanwood GmbH (www.stanwood.io)
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
 
 import Foundation
 import ObjectMapper

--- a/STWSocialKit/Classes/STLike.swift
+++ b/STWSocialKit/Classes/STLike.swift
@@ -1,8 +1,8 @@
 //
 //  FBLike.swift
-//  Mach_Dich_Krass
+//  StanwoodSocial
 //
-//  Created by Tal Zion on 11/11/2016.
+//  Copyright (c) 2018 stanwood GmbH
 //
 //  The MIT License (MIT)
 //

--- a/STWSocialKit/Classes/STLike.swift
+++ b/STWSocialKit/Classes/STLike.swift
@@ -3,10 +3,8 @@
 //  StanwoodSocial
 //
 //  Copyright (c) 2018 stanwood GmbH
-<<<<<<< Updated upstream
-=======
 //  Distributed under MIT licence.
->>>>>>> Stashed changes
+
 //
 //  The MIT License (MIT)
 //

--- a/STWSocialKit/Classes/STLike.swift
+++ b/STWSocialKit/Classes/STLike.swift
@@ -3,6 +3,10 @@
 //  StanwoodSocial
 //
 //  Copyright (c) 2018 stanwood GmbH
+<<<<<<< Updated upstream
+=======
+//  Distributed under MIT licence.
+>>>>>>> Stashed changes
 //
 //  The MIT License (MIT)
 //

--- a/STWSocialKit/Classes/STLocalizedCommentStrings.swift
+++ b/STWSocialKit/Classes/STLocalizedCommentStrings.swift
@@ -3,8 +3,28 @@
 //  Mach_Dich_Krass
 //
 //  Created by Tal Zion on 25/11/2016.
-//  Copyright © 2016 Stanwood GmbH. All rights reserved.
 //
+//  The MIT License (MIT)
+//
+//  Copyright (c) 2018 Stanwood GmbH (www.stanwood.io)
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
 
 import Foundation
 

--- a/STWSocialKit/Classes/STLocalizedCommentStrings.swift
+++ b/STWSocialKit/Classes/STLocalizedCommentStrings.swift
@@ -3,10 +3,8 @@
 //  StanwoodSocial
 //
 //  Copyright (c) 2018 stanwood GmbH
-<<<<<<< Updated upstream
-=======
 //  Distributed under MIT licence.
->>>>>>> Stashed changes
+
 //
 //  The MIT License (MIT)
 //

--- a/STWSocialKit/Classes/STLocalizedCommentStrings.swift
+++ b/STWSocialKit/Classes/STLocalizedCommentStrings.swift
@@ -3,6 +3,10 @@
 //  StanwoodSocial
 //
 //  Copyright (c) 2018 stanwood GmbH
+<<<<<<< Updated upstream
+=======
+//  Distributed under MIT licence.
+>>>>>>> Stashed changes
 //
 //  The MIT License (MIT)
 //

--- a/STWSocialKit/Classes/STLocalizedCommentStrings.swift
+++ b/STWSocialKit/Classes/STLocalizedCommentStrings.swift
@@ -1,8 +1,8 @@
 //
 //  STLocalizedCommentStrings.swift
-//  Mach_Dich_Krass
+//  StanwoodSocial
 //
-//  Created by Tal Zion on 25/11/2016.
+//  Copyright (c) 2018 stanwood GmbH
 //
 //  The MIT License (MIT)
 //

--- a/STWSocialKit/Classes/STLocalizedShareStrings.swift
+++ b/STWSocialKit/Classes/STLocalizedShareStrings.swift
@@ -1,8 +1,8 @@
 //
 //  File.swift
-//  Mach_Dich_Krass
+//  StanwoodSocial
 //
-//  Created by Tal Zion on 25/11/2016.
+//  Copyright (c) 2018 stanwood GmbH
 //
 //  The MIT License (MIT)
 //

--- a/STWSocialKit/Classes/STLocalizedShareStrings.swift
+++ b/STWSocialKit/Classes/STLocalizedShareStrings.swift
@@ -3,8 +3,28 @@
 //  Mach_Dich_Krass
 //
 //  Created by Tal Zion on 25/11/2016.
-//  Copyright © 2016 Stanwood GmbH. All rights reserved.
 //
+//  The MIT License (MIT)
+//
+//  Copyright (c) 2018 Stanwood GmbH (www.stanwood.io)
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
 
 import Foundation
 

--- a/STWSocialKit/Classes/STLocalizedShareStrings.swift
+++ b/STWSocialKit/Classes/STLocalizedShareStrings.swift
@@ -3,10 +3,8 @@
 //  StanwoodSocial
 //
 //  Copyright (c) 2018 stanwood GmbH
-<<<<<<< Updated upstream
-=======
 //  Distributed under MIT licence.
->>>>>>> Stashed changes
+
 //
 //  The MIT License (MIT)
 //

--- a/STWSocialKit/Classes/STLocalizedShareStrings.swift
+++ b/STWSocialKit/Classes/STLocalizedShareStrings.swift
@@ -3,6 +3,10 @@
 //  StanwoodSocial
 //
 //  Copyright (c) 2018 stanwood GmbH
+<<<<<<< Updated upstream
+=======
+//  Distributed under MIT licence.
+>>>>>>> Stashed changes
 //
 //  The MIT License (MIT)
 //

--- a/STWSocialKit/Classes/STSocialConfiguration.swift
+++ b/STWSocialKit/Classes/STSocialConfiguration.swift
@@ -3,8 +3,28 @@
 //  Mach_Dich_Krass
 //
 //  Created by Tal Zion on 15/11/2016.
-//  Copyright © 2016 Stanwood GmbH. All rights reserved.
 //
+//  The MIT License (MIT)
+//
+//  Copyright (c) 2018 Stanwood GmbH (www.stanwood.io)
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
 
 import Foundation
 import FBSDKLoginKit

--- a/STWSocialKit/Classes/STSocialConfiguration.swift
+++ b/STWSocialKit/Classes/STSocialConfiguration.swift
@@ -3,10 +3,8 @@
 //  StanwoodSocial
 //
 //  Copyright (c) 2018 stanwood GmbH
-<<<<<<< Updated upstream
-=======
 //  Distributed under MIT licence.
->>>>>>> Stashed changes
+
 //
 //  The MIT License (MIT)
 //

--- a/STWSocialKit/Classes/STSocialConfiguration.swift
+++ b/STWSocialKit/Classes/STSocialConfiguration.swift
@@ -3,6 +3,10 @@
 //  StanwoodSocial
 //
 //  Copyright (c) 2018 stanwood GmbH
+<<<<<<< Updated upstream
+=======
+//  Distributed under MIT licence.
+>>>>>>> Stashed changes
 //
 //  The MIT License (MIT)
 //

--- a/STWSocialKit/Classes/STSocialConfiguration.swift
+++ b/STWSocialKit/Classes/STSocialConfiguration.swift
@@ -1,8 +1,8 @@
 //
 //  STSocialConfiguration.swift
-//  Mach_Dich_Krass
+//  StanwoodSocial
 //
-//  Created by Tal Zion on 15/11/2016.
+//  Copyright (c) 2018 stanwood GmbH
 //
 //  The MIT License (MIT)
 //

--- a/STWSocialKit/Classes/STSocialManager.swift
+++ b/STWSocialKit/Classes/STSocialManager.swift
@@ -3,8 +3,28 @@
 //  Mach_Dich_Krass
 //
 //  Created by Tal Zion on 31/10/2016.
-//  Copyright © 2016 Stanwood GmbH. All rights reserved.
 //
+//  The MIT License (MIT)
+//
+//  Copyright (c) 2018 Stanwood GmbH (www.stanwood.io)
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
 
 import Foundation
 import OAuthSwift

--- a/STWSocialKit/Classes/STSocialManager.swift
+++ b/STWSocialKit/Classes/STSocialManager.swift
@@ -3,10 +3,8 @@
 //  StanwoodSocial
 //
 //  Copyright (c) 2018 stanwood GmbH
-<<<<<<< Updated upstream
-=======
 //  Distributed under MIT licence.
->>>>>>> Stashed changes
+
 //
 //  The MIT License (MIT)
 //

--- a/STWSocialKit/Classes/STSocialManager.swift
+++ b/STWSocialKit/Classes/STSocialManager.swift
@@ -1,8 +1,8 @@
 //
 //  STSocialConfiguration.swift
-//  Mach_Dich_Krass
+//  StanwoodSocial
 //
-//  Created by Tal Zion on 31/10/2016.
+//  Copyright (c) 2018 stanwood GmbH
 //
 //  The MIT License (MIT)
 //

--- a/STWSocialKit/Classes/STSocialManager.swift
+++ b/STWSocialKit/Classes/STSocialManager.swift
@@ -3,6 +3,10 @@
 //  StanwoodSocial
 //
 //  Copyright (c) 2018 stanwood GmbH
+<<<<<<< Updated upstream
+=======
+//  Distributed under MIT licence.
+>>>>>>> Stashed changes
 //
 //  The MIT License (MIT)
 //

--- a/STWSocialKit/Classes/STSocialService.swift
+++ b/STWSocialKit/Classes/STSocialService.swift
@@ -1,8 +1,8 @@
 //
 //  STSocialService.swift
-//  Mach_Dich_Krass
+//  StanwoodSocial
 //
-//  Created by Tal Zion on 31/10/2016.
+//  Copyright (c) 2018 stanwood GmbH
 //
 //  The MIT License (MIT)
 //

--- a/STWSocialKit/Classes/STSocialService.swift
+++ b/STWSocialKit/Classes/STSocialService.swift
@@ -3,8 +3,28 @@
 //  Mach_Dich_Krass
 //
 //  Created by Tal Zion on 31/10/2016.
-//  Copyright © 2016 Stanwood GmbH. All rights reserved.
 //
+//  The MIT License (MIT)
+//
+//  Copyright (c) 2018 Stanwood GmbH (www.stanwood.io)
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
 
 import Foundation
 import Locksmith

--- a/STWSocialKit/Classes/STSocialService.swift
+++ b/STWSocialKit/Classes/STSocialService.swift
@@ -3,10 +3,8 @@
 //  StanwoodSocial
 //
 //  Copyright (c) 2018 stanwood GmbH
-<<<<<<< Updated upstream
-=======
 //  Distributed under MIT licence.
->>>>>>> Stashed changes
+
 //
 //  The MIT License (MIT)
 //

--- a/STWSocialKit/Classes/STSocialService.swift
+++ b/STWSocialKit/Classes/STSocialService.swift
@@ -3,6 +3,10 @@
 //  StanwoodSocial
 //
 //  Copyright (c) 2018 stanwood GmbH
+<<<<<<< Updated upstream
+=======
+//  Distributed under MIT licence.
+>>>>>>> Stashed changes
 //
 //  The MIT License (MIT)
 //

--- a/STWSocialKit/Classes/STWebViewController.swift
+++ b/STWSocialKit/Classes/STWebViewController.swift
@@ -3,10 +3,8 @@
 //  StanwoodSocial
 //
 //  Copyright (c) 2018 stanwood GmbH
-<<<<<<< Updated upstream
-=======
 //  Distributed under MIT licence.
->>>>>>> Stashed changes
+
 //
 //  The MIT License (MIT)
 //

--- a/STWSocialKit/Classes/STWebViewController.swift
+++ b/STWSocialKit/Classes/STWebViewController.swift
@@ -3,6 +3,10 @@
 //  StanwoodSocial
 //
 //  Copyright (c) 2018 stanwood GmbH
+<<<<<<< Updated upstream
+=======
+//  Distributed under MIT licence.
+>>>>>>> Stashed changes
 //
 //  The MIT License (MIT)
 //

--- a/STWSocialKit/Classes/STWebViewController.swift
+++ b/STWSocialKit/Classes/STWebViewController.swift
@@ -3,8 +3,28 @@
 //  Mach_Dich_Krass
 //
 //  Created by Tal Zion on 16/11/2016.
-//  Copyright © 2016 Stanwood GmbH. All rights reserved.
 //
+//  The MIT License (MIT)
+//
+//  Copyright (c) 2018 Stanwood GmbH (www.stanwood.io)
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
 
 import OAuthSwift
 import UIKit

--- a/STWSocialKit/Classes/STWebViewController.swift
+++ b/STWSocialKit/Classes/STWebViewController.swift
@@ -1,8 +1,8 @@
 //
 //  WebViewController.swift
-//  Mach_Dich_Krass
+//  StanwoodSocial
 //
-//  Created by Tal Zion on 16/11/2016.
+//  Copyright (c) 2018 stanwood GmbH
 //
 //  The MIT License (MIT)
 //

--- a/StanwoodSocial.podspec
+++ b/StanwoodSocial.podspec
@@ -19,7 +19,7 @@ s.license          = { :type => 'MIT', :file => 'LICENSE' }
 s.author           = { 'Tal Zion' => 'talezion@gmail.com' }
 s.source           = { :git => 'https://github.com/stanwood/StanwoodSocial.git', :tag => s.version.to_s }
 
-s.ios.deployment_target = '9.3'
+s.ios.deployment_target = '10'
 s.requires_arc = true
 
 s.source_files = 'STWSocialKit/Classes/**/*'

--- a/StanwoodSocial.podspec
+++ b/StanwoodSocial.podspec
@@ -1,5 +1,5 @@
 #
-# Be sure to run `pod lib lint STWSocialKit.podspec' to ensure this is a
+# Be sure to run `pod lib lint StanwoodSocial.podspec' to ensure this is a
 # valid spec before submitting.
 #
 # Any lines starting with a # are optional, but their use is encouraged
@@ -8,21 +8,21 @@
 
 Pod::Spec.new do |s|
 s.name             = 'StanwoodSocial'
-s.version          = '0.1.8'
+s.version          = '0.1.9'
 s.summary          = 'Wrapper for social media SDKs'
 s.description      = <<-DESC
 'Wrapper for social media sdk'
 DESC
 
-s.homepage         = 'https://github.com/stanwood/STWSocialKit'
-s.license          = { :type => 'Private', :file => 'LICENSE' }
+s.homepage         = 'https://github.com/stanwood/StanwoodSocial'
+s.license          = { :type => 'MIT', :file => 'LICENSE' }
 s.author           = { 'Tal Zion' => 'talezion@gmail.com' }
-s.source           = { :git => 'git@github.com:stanwood/STWSocialKit.git', :tag => s.version.to_s }
+s.source           = { :git => 'https://github.com:stanwood/StanwoodSocial.git', :tag => s.version.to_s }
 
 s.ios.deployment_target = '9.3'
 s.requires_arc = true
 
-s.source_files = 'STWSocialKit/Classes/**/*'
+s.source_files = 'StanwoodSocial/Classes/**/*'
 s.resource_bundles = {
 }
 

--- a/StanwoodSocial.podspec
+++ b/StanwoodSocial.podspec
@@ -1,10 +1,3 @@
-#
-# Be sure to run `pod lib lint StanwoodSocial.podspec' to ensure this is a
-# valid spec before submitting.
-#
-# Any lines starting with a # are optional, but their use is encouraged
-# To learn more about a Podspec see http://guides.cocoapods.org/syntax/podspec.html
-#
 
 Pod::Spec.new do |s|
 s.name             = 'StanwoodSocial'

--- a/StanwoodSocial.podspec
+++ b/StanwoodSocial.podspec
@@ -1,7 +1,7 @@
 
 Pod::Spec.new do |s|
 s.name             = 'StanwoodSocial'
-s.version          = '0.1.9'
+s.version          = '1.0.0'
 s.summary          = 'Wrapper for social media SDKs'
 s.description      = <<-DESC
 'Wrapper for social media sdk'
@@ -12,7 +12,7 @@ s.license          = { :type => 'MIT', :file => 'LICENSE' }
 s.author           = { 'Tal Zion' => 'talezion@gmail.com' }
 s.source           = { :git => 'https://github.com/stanwood/StanwoodSocial.git', :tag => s.version.to_s }
 
-s.ios.deployment_target = '10'
+s.ios.deployment_target = '9.3'
 s.requires_arc = true
 
 s.source_files = 'STWSocialKit/Classes/**/*'

--- a/StanwoodSocial.podspec
+++ b/StanwoodSocial.podspec
@@ -17,12 +17,12 @@ DESC
 s.homepage         = 'https://github.com/stanwood/StanwoodSocial'
 s.license          = { :type => 'MIT', :file => 'LICENSE' }
 s.author           = { 'Tal Zion' => 'talezion@gmail.com' }
-s.source           = { :git => 'https://github.com:stanwood/StanwoodSocial.git', :tag => s.version.to_s }
+s.source           = { :git => 'https://github.com/stanwood/StanwoodSocial.git', :tag => s.version.to_s }
 
 s.ios.deployment_target = '9.3'
 s.requires_arc = true
 
-s.source_files = 'StanwoodSocial/Classes/**/*'
+s.source_files = 'STWSocialKit/Classes/**/*'
 s.resource_bundles = {
 }
 


### PR DESCRIPTION
## WIP

## Description

Ticket: [SFW-149](https://stanwood.atlassian.net/browse/SFW-149)

✅ Update licence in .podspec to MIT
✅ Update README licence to MIT
✅ Update LICENCE file to MIT
✅ Set s.source to HTTP, instead of ssh
✅ Update Usage(Installation guide)
✅ Replace the headers in all source files. and include copyright and MIT licence
✅ Replace the string in the Example launch screen to state copyright Stanwood GmbH.
✅ Check spelling of class and folder names.
✅ Cleanup the Podspec file and ensure that it has both a meaningful summary and description.
✅ Ensure the the Podfile in the example project has "platform :ios, 10".
✅ Version bump, and 
❌ push to master repo